### PR TITLE
Add space learning topic

### DIFF
--- a/app/lesson/[lessonId]/page.tsx
+++ b/app/lesson/[lessonId]/page.tsx
@@ -238,6 +238,12 @@ export default function LessonPage({ params }: { params: { lessonId: string } })
           border: 'border-purple-400',
           text: 'text-purple-800'
         }
+      case 'space':
+        return {
+          bg: 'bg-indigo-300',
+          border: 'border-indigo-400',
+          text: 'text-indigo-800'
+        }
       default:
         return {
           bg: 'bg-green-300',
@@ -298,13 +304,13 @@ export default function LessonPage({ params }: { params: { lessonId: string } })
         <div className={`${clayCard} ${colors.bg} ${colors.border} p-6 mb-8 transform -rotate-1`}>
           <div className="flex items-start gap-6">
             <div className="relative w-20 h-20 flex-shrink-0">
-              {lesson.category === 'math' && (
+              {(lesson.category === 'math' || lesson.category === 'space') && (
                 <Image src="/star.png" alt={lesson.category} fill className="object-contain drop-shadow-md" />
               )}
               {lesson.category === 'robots' && (
                 <Image src="/robot.png" alt={lesson.category} fill className="object-contain drop-shadow-md" />
               )}
-              {!['math', 'robots'].includes(lesson.category) && (
+              {!['math', 'robots', 'space'].includes(lesson.category) && (
                 <Image src="/bulb.png" alt={lesson.category} fill className="object-contain drop-shadow-md" />
               )}
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -134,6 +134,11 @@ export default function Home() {
         recommendLesson = true
         lessonId = "robots-intro-001"
         break
+      case "space":
+        prompt = "Tell me something cool about space!"
+        recommendLesson = true
+        lessonId = "space-planets-001"
+        break
     }
 
     setQuestion(prompt)
@@ -200,6 +205,22 @@ export default function Home() {
             window.location.href = `/lesson/${lessonId}`
           }, 1500)
           
+        } else if (recentText.includes("space") || recentText.includes("planet")) {
+          lessonId = "space-planets-001"
+
+          setMessages(prev => [
+            ...prev,
+            {
+              type: "assistant",
+              content: "Awesome! Let's start the space lesson. I'll take you there now!",
+            },
+          ])
+
+          // Short delay before redirecting to the lesson
+          setTimeout(() => {
+            window.location.href = `/lesson/${lessonId}`
+          }, 1500)
+
         } else {
           // Default to math patterns lesson
           setMessages(prev => [
@@ -608,6 +629,22 @@ export default function Home() {
                       </div>
                     </div>
                   </Link>
+                  <Link href="/lesson/space-planets-001" className="block">
+                    <div className={`${clayCard} border-indigo-400 bg-indigo-300 p-4 transform rotate-1 hover:rotate-2 hover:scale-105 transition-all duration-300 cursor-pointer`}>
+                      <div className="flex justify-between items-start">
+                        <div>
+                          <p className="text-lg font-bold text-indigo-800 mb-1">Space Adventure</p>
+                          <div className="mt-1 flex items-center">
+                            <span className="text-indigo-800 font-medium px-3 py-1 bg-indigo-200 rounded-full text-sm mr-2 border-2 border-indigo-400">Space</span>
+                            <span className="text-sm font-bold text-indigo-800">10 min</span>
+                          </div>
+                        </div>
+                        <div className="relative w-10 h-10 animate-pulse-slow">
+                          <Image src="/star.png" alt="Space" fill className="object-contain drop-shadow-md" />
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
                 </div>
               </div>
             )}
@@ -617,8 +654,8 @@ export default function Home() {
               <div className="mb-6">
                 <p className="text-lg font-bold text-purple-800 mb-3">What do you want to talk about?</p>
                 <div className="flex flex-wrap gap-3">
-                  <button 
-                    onClick={() => handleTopicSelect('math')} 
+                  <button
+                    onClick={() => handleTopicSelect('math')}
                     className="px-5 py-3 bg-blue-300 text-blue-800 rounded-full text-lg font-bold border-4 border-blue-400 shadow-md hover:shadow-lg hover:scale-110 active:scale-95 transition-all duration-200 transform hover:-rotate-3"
                   >
                     Math Help 🔢
@@ -629,11 +666,17 @@ export default function Home() {
                   >
                     Cool Ideas 💡
                   </button>
-                  <button 
-                    onClick={() => handleTopicSelect('robots')} 
+                  <button
+                    onClick={() => handleTopicSelect('robots')}
                     className="px-5 py-3 bg-orange-300 text-orange-800 rounded-full text-lg font-bold border-4 border-orange-400 shadow-md hover:shadow-lg hover:scale-110 active:scale-95 transition-all duration-200 transform hover:-rotate-3"
                   >
                     Robots 🤖
+                  </button>
+                  <button
+                    onClick={() => handleTopicSelect('space')}
+                    className="px-5 py-3 bg-indigo-300 text-indigo-800 rounded-full text-lg font-bold border-4 border-indigo-400 shadow-md hover:shadow-lg hover:scale-110 active:scale-95 transition-all duration-200 transform hover:rotate-3"
+                  >
+                    Space 🪐
                   </button>
                 </div>
               </div>

--- a/components/topic-bubbles.tsx
+++ b/components/topic-bubbles.tsx
@@ -11,6 +11,7 @@ export default function TopicBubbles({ onSelect }: TopicBubblesProps) {
     { id: "math", emoji: "🧮", label: "Math" },
     { id: "ideas", emoji: "💡", label: "Ideas" },
     { id: "robots", emoji: "🤖", label: "Robots" },
+    { id: "space", emoji: "🪐", label: "Space" },
   ]
 
   return (
@@ -27,7 +28,9 @@ export default function TopicBubbles({ onSelect }: TopicBubblesProps) {
                 ? "rgba(191, 219, 254, 0.8)"
                 : topic.id === "ideas"
                   ? "rgba(254, 240, 138, 0.8)"
-                  : "rgba(253, 186, 186, 0.8)",
+                  : topic.id === "space"
+                    ? "rgba(199, 210, 254, 0.8)"
+                    : "rgba(253, 186, 186, 0.8)",
           }}
         >
           <span>{topic.emoji}</span>

--- a/lib/lesson-plans.ts
+++ b/lib/lesson-plans.ts
@@ -179,6 +179,69 @@ export const sampleLessonPlans: LessonPlan[] = [
       ]
     },
     tags: ['robots', 'technology', 'STEM']
+  },
+  {
+    id: 'space-planets-001',
+    title: 'Exploring the Solar System',
+    category: 'space',
+    gradeLevel: ['3-5', '6-8'],
+    author: {
+      name: 'Sunny AI',
+      id: 'system'
+    },
+    isPublic: true,
+    dateCreated: new Date().toISOString(),
+    dateModified: new Date().toISOString(),
+    content: {
+      id: 'space-planets-001-content',
+      title: 'Our Amazing Solar System',
+      description: 'Discover the planets and what makes each one special',
+      keywords: ['space', 'planets', 'solar system'],
+      learningOutcomes: [
+        'Identify planets in our solar system',
+        'Describe key features of each planet',
+        'Understand the order of planets from the sun'
+      ],
+      activities: [
+        {
+          id: 'planet-order',
+          type: 'multiple-choice',
+          title: 'Planet Order',
+          description: 'Which planet is third from the sun?',
+          difficulty: 'beginner',
+          estimatedTimeMinutes: 5,
+          ageRange: { min: 8, max: 12 },
+          content: {
+            question: 'Which planet is third from the sun?',
+            options: ['Earth', 'Mars', 'Venus', 'Mercury'],
+            correctAnswer: 'Earth'
+          }
+        },
+        {
+          id: 'my-planet',
+          type: 'creative',
+          title: 'Design Your Planet',
+          description: 'Imagine your own planet',
+          difficulty: 'beginner',
+          estimatedTimeMinutes: 10,
+          ageRange: { min: 8, max: 12 },
+          content: {
+            instructions: 'Design your own planet! Describe what it looks like and who might live there.',
+            examples: ['A planet covered in oceans', 'A planet with purple trees'],
+            submissionType: 'text'
+          }
+        }
+      ],
+      relatedTopics: ['astronomy', 'science'],
+      additionalResources: [
+        {
+          title: 'NASA Kids Club',
+          url: 'https://www.nasa.gov/kidsclub/index.html',
+          type: 'game'
+        }
+      ]
+    },
+    tags: ['space', 'planets', 'science']
   }
 ];
 

--- a/lib/sunny-ai.ts
+++ b/lib/sunny-ai.ts
@@ -12,6 +12,8 @@ export async function generateSunnyResponse(prompt: string, name: string): Promi
     robot:
       "Robots are machines that can be programmed to do tasks! 🤖 Some robots can dance, some can explore Mars, and some can even help doctors perform surgery! What kind of robot would you invent?",
     idea: "Ideas are like little lightbulbs that pop up in your mind! 💡 The best ideas often come when you're having fun or solving problems. What's something you'd like to invent?",
+    space:
+      "Space is full of amazing planets and stars! 🌌 Did you know there are more stars in the universe than grains of sand on Earth? Which planet is your favorite?",
     hello: `Hi there, ${name}! It's great to chat with you! What would you like to learn about today?`,
     "how are you": `I'm sunny and bright today, thanks for asking! How about you, ${name}? What would you like to explore?`,
   }
@@ -57,6 +59,12 @@ export async function generateMiniChallenge(topic: string): Promise<any> {
       question: "Which of these helps a robot 'see'?",
       options: ["Camera", "Speaker", "Wheel", "Battery"],
       correctAnswer: "Camera",
+    },
+    space: {
+      type: "multiple-choice",
+      question: "Which planet is known as the Red Planet?",
+      options: ["Earth", "Mars", "Jupiter", "Venus"],
+      correctAnswer: "Mars",
     },
   }
 


### PR DESCRIPTION
## Summary
- add 'space-planets-001' lesson plan example
- extend Sunny AI mock with responses and challenges about space
- show new "Space" topic button and related lesson card
- support space category in lesson page UI

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_683f664c2964832e9dc246c6eccb2574